### PR TITLE
Config preview with sensors and labels

### DIFF
--- a/api_li3ds/apis/platform.py
+++ b/api_li3ds/apis/platform.py
@@ -130,7 +130,6 @@ class OnePlatformConfig(Resource):
         return '', 410
 
 
-
 @nspfm.route('/configs/<int:id>/dot/', endpoint='platform_config_dot')
 @nspfm.param('id', 'The platform config identifier')
 class PlatformConfigDot(Resource):
@@ -150,6 +149,7 @@ class PlatformConfigDot(Resource):
         response.headers['content-type'] = 'text/plain'
         response.mimetype = 'text/plain'
         return response
+
 
 @nspfm.route('/configs/<int:id>/preview/', endpoint='platform_config_preview')
 @nspfm.param('id', 'The platform config identifier')

--- a/api_li3ds/apis/platform.py
+++ b/api_li3ds/apis/platform.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from flask import make_response
+from flask import url_for
 from flask_restplus import fields
 from graphviz import Digraph
 
@@ -39,6 +40,74 @@ platform_config = nspfm.inherit(
     {
         'id': fields.Integer,
     })
+
+
+def platform_config_dot(id):
+
+    config = Database.query("""
+        select * from li3ds.platform_config where id = %s limit 1
+    """, (id, ))[0]
+
+    edges = Database.query(
+        """
+        select t.id, t.source, t.target, t.transfo_type, tf.sc, tft.name
+        from (
+            select distinct
+                unnest(tt.transfos) as tid, sensor_connections as sc
+            from li3ds.transfo_tree tt where tt.id = ANY(%s)
+        ) as tf
+        join li3ds.transfo t on t.id = tf.tid
+        join li3ds.transfo_type tft on tft.id = t.transfo_type
+        """, (list(config.transfo_trees), )
+    )
+    urefs = set()
+    for edge in edges:
+        urefs.add(edge.source)
+        urefs.add(edge.target)
+
+    nodes = Database.query("""
+        select distinct id, name, root, sensor
+        from li3ds.referential where ARRAY[id] <@ %s
+    """, (list(urefs), ))
+
+    sensors = Database.query("""
+        select distinct id, name
+        from li3ds.sensor where ARRAY[id] <@ %s
+    """, (list(urefs), ))
+
+    url = url_for('platform_config_dot',id=id,_external=True)
+    dot = Digraph(name="config_{}".format(id),comment=url)
+    dot.graph_attr.update({
+        'label': "Platform {} : {} ({})".format(config.platform, config.name, config.id),
+        'overlap': 'scalexy'
+    })
+
+    subgraphs = {}
+
+    for sensor in sensors:
+        subgraphs[sensor.id] = Digraph(name="cluster_{}".format(sensor.id))
+        subgraphs[sensor.id].graph_attr.update({
+            'label': "{} ({})".format(sensor.name, sensor.id)
+        })
+
+    for node in nodes:
+        color = 'red' if node.root else 'black'
+        subgraphs[node.sensor].node(str(node.id), '{}\n({})'.format(node.name, node.id), color=color)
+
+    for sensor in sensors:
+        dot.subgraph(subgraphs[sensor.id])
+
+    for edge in edges:
+        # highlight sensor connections in blue
+        color = 'blue' if edge.sc else 'black'
+        dot.edge(
+            str(edge.source),
+            str(edge.target),
+            label='{}\n({})'.format(edge.name, edge.id),
+            color=color)
+
+    dot.engine = 'dot'
+    return dot
 
 
 @nspfm.route('/', endpoint='platforms')
@@ -130,6 +199,20 @@ class OnePlatformConfig(Resource):
         return '', 410
 
 
+
+@nspfm.route('/configs/<int:id>/dot/', endpoint='platform_config_dot')
+@nspfm.param('id', 'The platform config identifier')
+class PlatformConfigDot(Resource):
+
+    def get(self, id):
+        '''Get a preview for this platform configuration as dot
+
+        Nodes are referentials and edges are tranformations between referentials.
+        Blue arrows represents connections between sensors (or sensor groups).
+        Red nodes are root referentials
+        '''
+        return make_response(platform_config_dot(id).source)
+
 @nspfm.route('/configs/<int:id>/preview/', endpoint='platform_config_preview')
 @nspfm.param('id', 'The platform config identifier')
 class PlatformConfigPreview(Resource):
@@ -141,53 +224,7 @@ class PlatformConfigPreview(Resource):
         Blue arrows represents connections between sensors (or sensor groups).
         Red nodes are root referentials
         '''
-        edges = Database.query(
-            """
-            with tmp as (
-                select
-                    unnest(tt.transfos) as tid, sensor_connections as sc
-                from li3ds.platform_config pf
-                join li3ds.transfo_tree tt on tt.id = ANY(pf.transfo_trees)
-                where pf.id = %s
-            ) select distinct t.id, t.source, t.target, transfo_type, p.sc
-            from tmp p
-            join li3ds.transfo t on t.id = p.tid
-            """, (id, )
-        )
-        urefs = set()
-        for edge in edges:
-            urefs.add(edge.source)
-            urefs.add(edge.target)
-
-        nodes = Database.query("""
-            select distinct id, name, root
-            from li3ds.referential where ARRAY[id] <@ %s
-        """, (list(urefs), ))
-
-        dot = Digraph(comment='Transformations')
-
-        for node in nodes:
-            if node.root:
-                dot.node(str(node.id), '{}\n({})'.format(node.name, node.id), color='red')
-                continue
-            dot.node(str(node.id), '{}\n({})'.format(node.name, node.id))
-
-        for edge in edges:
-            if edge.sc:
-                # highlight sensor connections in blue
-                dot.edge(
-                    str(edge.source),
-                    str(edge.target),
-                    label='{}'.format(edge.id),
-                    color='blue')
-                continue
-            dot.edge(
-                str(edge.source),
-                str(edge.target),
-                label='{}'.format(edge.id))
-
-        dot.graph_attr = {'overlap': 'scalexy'}
-        dot.engine = 'dot'
+        dot = platform_config_dot(id)
         data = dot.pipe("png")
 
         response = make_response(data)

--- a/api_li3ds/apis/platform.py
+++ b/api_li3ds/apis/platform.py
@@ -51,7 +51,7 @@ def platform_config_dot(id):
 
     edges = Database.query(
         """
-        select t.id, t.source, t.target, t.transfo_type, tf.sc, tft.func_name
+        select t.id, t.source, t.target, t.transfo_type, tf.sc, tft.name
         from (
             select distinct
                 unnest(tt.transfos) as tid, sensor_connections as sc
@@ -72,7 +72,7 @@ def platform_config_dot(id):
     """, (list(urefs), ))
 
     sensors = Database.query("""
-        select distinct id, short_name as name
+        select distinct id, name
         from li3ds.sensor where ARRAY[id] <@ %s
     """, (list(urefs), ))
 
@@ -104,7 +104,7 @@ def platform_config_dot(id):
         dot.edge(
             str(edge.source),
             str(edge.target),
-            label='{}\n({})'.format(edge.func_name, edge.id),
+            label='{}\n({})'.format(edge.name, edge.id),
             color=color)
 
     dot.engine = 'dot'

--- a/api_li3ds/apis/platform.py
+++ b/api_li3ds/apis/platform.py
@@ -4,7 +4,7 @@ from flask_restplus import fields
 
 from api_li3ds.app import api, Resource, defaultpayload
 from api_li3ds.database import Database
-from api_li3ds.dot import Dot
+from api_li3ds import dot
 from .sensor import sensor_model
 
 nspfm = api.namespace('platforms', description='platforms related operations')
@@ -141,11 +141,11 @@ class PlatformConfigDot(Resource):
         Blue arrows represents connections between sensors (or sensor groups).
         Red nodes are root referentials
         '''
-        dot = Dot.platform_config(id)
-        if not dot:
+        graph = dot.platform_config(id)
+        if not graph:
             nspfm.abort(404, 'Platform configuration not found')
 
-        response = make_response(dot.source)
+        response = make_response(graph.source)
         response.headers['content-type'] = 'text/plain'
         response.mimetype = 'text/plain'
         return response
@@ -162,11 +162,11 @@ class PlatformConfigPreview(Resource):
         Blue arrows represents connections between sensors (or sensor groups).
         Red nodes are root referentials
         '''
-        dot = Dot.platform_config(id)
-        if not dot:
+        graph = dot.platform_config(id)
+        if not graph:
             nspfm.abort(404, 'Platform configuration not found')
 
-        response = make_response(dot.pipe("png"))
+        response = make_response(graph.pipe("png"))
         response.headers['content-type'] = 'image/png'
         response.mimetype = 'image/png'
         return response

--- a/api_li3ds/apis/transfotree.py
+++ b/api_li3ds/apis/transfotree.py
@@ -74,6 +74,7 @@ class OneTransfoTree(Resource):
             nstft.abort(404, 'Transformation tree not found')
         return '', 410
 
+
 @nstft.route('/<int:id>/dot/', endpoint='transfotree_dot')
 @nstft.param('id', 'The platform config identifier')
 class TransfoTreeDot(Resource):
@@ -93,6 +94,7 @@ class TransfoTreeDot(Resource):
         response.headers['content-type'] = 'text/plain'
         response.mimetype = 'text/plain'
         return response
+
 
 @nstft.route('/<int:id>/preview/', endpoint='transfotree_preview')
 @nstft.param('id', 'The platform config identifier')

--- a/api_li3ds/apis/transfotree.py
+++ b/api_li3ds/apis/transfotree.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
+from flask import make_response
 from flask_restplus import fields
 
 from api_li3ds.app import api, Resource, defaultpayload
 from api_li3ds.database import Database
+from api_li3ds.dot import Dot
 
 nstft = api.namespace('transfotrees', description='transformation trees related operations')
 
@@ -71,3 +73,43 @@ class OneTransfoTree(Resource):
         if not res:
             nstft.abort(404, 'Transformation tree not found')
         return '', 410
+
+@nstft.route('/<int:id>/dot/', endpoint='transfotree_dot')
+@nstft.param('id', 'The platform config identifier')
+class TransfoTreeDot(Resource):
+
+    def get(self, id):
+        '''Get a preview for this transfo tree as dot
+
+        Nodes are referentials and edges are tranformations between referentials.
+        Blue arrows represents connections between sensors (or sensor groups).
+        Red nodes are root referentials
+        '''
+        dot = Dot.transfo_tree(id)
+        if not dot:
+            nstft.abort(404, 'Transformation tree not found')
+
+        response = make_response(dot.source)
+        response.headers['content-type'] = 'text/plain'
+        response.mimetype = 'text/plain'
+        return response
+
+@nstft.route('/<int:id>/preview/', endpoint='transfotree_preview')
+@nstft.param('id', 'The platform config identifier')
+class TransfoTreePreview(Resource):
+
+    def get(self, id):
+        '''Get a preview for this transfo tree as png
+
+        Nodes are referentials and edges are tranformations between referentials.
+        Blue arrows represents connections between sensors (or sensor groups).
+        Red nodes are root referentials
+        '''
+        dot = Dot.transfo_tree(id)
+        if not dot:
+            nstft.abort(404, 'Transformation tree not found')
+
+        response = make_response(dot.pipe("png"))
+        response.headers['content-type'] = 'image/png'
+        response.mimetype = 'image/png'
+        return response

--- a/api_li3ds/apis/transfotree.py
+++ b/api_li3ds/apis/transfotree.py
@@ -4,7 +4,7 @@ from flask_restplus import fields
 
 from api_li3ds.app import api, Resource, defaultpayload
 from api_li3ds.database import Database
-from api_li3ds.dot import Dot
+from api_li3ds import dot
 
 nstft = api.namespace('transfotrees', description='transformation trees related operations')
 
@@ -86,11 +86,11 @@ class TransfoTreeDot(Resource):
         Blue arrows represents connections between sensors (or sensor groups).
         Red nodes are root referentials
         '''
-        dot = Dot.transfo_tree(id)
-        if not dot:
+        graph = dot.transfo_tree(id)
+        if not graph:
             nstft.abort(404, 'Transformation tree not found')
 
-        response = make_response(dot.source)
+        response = make_response(graph.source)
         response.headers['content-type'] = 'text/plain'
         response.mimetype = 'text/plain'
         return response
@@ -107,11 +107,11 @@ class TransfoTreePreview(Resource):
         Blue arrows represents connections between sensors (or sensor groups).
         Red nodes are root referentials
         '''
-        dot = Dot.transfo_tree(id)
-        if not dot:
+        graph = dot.transfo_tree(id)
+        if not graph:
             nstft.abort(404, 'Transformation tree not found')
 
-        response = make_response(dot.pipe("png"))
+        response = make_response(graph.pipe("png"))
         response.headers['content-type'] = 'image/png'
         response.mimetype = 'image/png'
         return response

--- a/api_li3ds/dot.py
+++ b/api_li3ds/dot.py
@@ -3,6 +3,7 @@ from graphviz import Digraph
 
 from api_li3ds.database import Database
 
+
 class Dot():
     '''
     Graphviz wrapper to export li3ds database elements
@@ -85,7 +86,6 @@ class Dot():
         name = "cluster_config_{}".format(id)
         url = url_for('platform_config', id=id, _external=True)
         label = "Platform: {pname} ({pid})\\nConfiguration: {name} ({id})".format_map(config)
-        print (config)
         return Dot.transfo_trees(name, url, label, config['transfo_trees'])
 
     def transfo_tree(id):

--- a/api_li3ds/dot.py
+++ b/api_li3ds/dot.py
@@ -1,0 +1,103 @@
+from flask import url_for
+from graphviz import Digraph
+
+from api_li3ds.database import Database
+
+class Dot():
+    '''
+    Graphviz wrapper to export li3ds database elements
+    '''
+
+    def dot(name, url, label, nodes, edges):
+        dot = Digraph(name=name, comment=url)
+        dot.graph_attr.update({
+            'label': label,
+            'overlap': 'scalexy'
+        })
+
+        subgraphs = {}
+
+        for node in nodes:
+            if node.sensor not in subgraphs:
+                url = url_for('sensor', id=node.sensor, _external=True)
+                name = "cluster_sensor_{}".format(node.sensor)
+                label = "Sensor {type}: {sname} ({sensor})".format_map(node._asdict())
+                subgraphs[node.sensor] = Digraph(name=name, comment=url)
+                subgraphs[node.sensor].graph_attr.update({'label': label})
+            color = 'red' if node.root else 'black'
+            label='{name}\\n({id})'.format_map(node._asdict())
+            subgraphs[node.sensor].node(str(node.id), label=label, color=color)
+
+        for sensor in subgraphs:
+            dot.subgraph(subgraphs[sensor])
+
+        for edge in edges:
+            # highlight sensor connections in blue
+            color = 'blue' if edge.sc else 'black'
+            label='{tname}\\n({id})'.format_map(edge._asdict())
+            dot.edge(str(edge.source),str(edge.target),label=label,color=color)
+
+        dot.engine = 'dot'
+        return dot
+
+    def transfo_trees(name, url, label, ids):
+
+        edges = Database.query(
+            """
+            select t.id, t.source, t.target, t.transfo_type, tf.sc, t.name, tft.name as tname
+            from (
+                select distinct
+                    unnest(tt.transfos) as tid, sensor_connections as sc
+                from li3ds.transfo_tree tt where tt.id = ANY(%s)
+            ) as tf
+            join li3ds.transfo t on t.id = tf.tid
+            join li3ds.transfo_type tft on tft.id = t.transfo_type
+            """, (list(ids), )
+        )
+
+        urefs = set()
+        for edge in edges:
+            urefs.add(edge.source)
+            urefs.add(edge.target)
+
+        nodes = Database.query("""
+            select distinct r.id, r.name, r.root, r.sensor, s.name as sname, s.type
+            from li3ds.referential r
+            join li3ds.sensor s on r.sensor = s.id
+            where ARRAY[r.id] <@ %s
+        """, (list(urefs), ))
+
+        return Dot.dot(name, url, label, nodes, edges)
+
+    def platform_config(id):
+
+        configs = Database.query_asdict("""
+            select p.name as pname, p.id as pid, c.transfo_trees, c.id, c.name
+            from li3ds.platform_config c
+            join li3ds.platform p on p.id = c.platform
+            where c.id = %s
+        """, (id, ))
+
+        if not configs:
+            return None
+        config = configs[0]
+
+        name="cluster_config_{}".format(id)
+        url = url_for('platform_config', id=id, _external=True)
+        label = "Platform: {pname} ({pid})\\nConfiguration: {name} ({id})".format_map(config)
+        print (config)
+        return Dot.transfo_trees(name, url, label, config['transfo_trees'])
+
+    def transfo_tree(id):
+        transfo_trees = Database.query_asdict(
+            "select * from li3ds.transfo_tree where id=%s", (id,)
+        )
+        if not transfo_trees:
+            return None
+        transfo_tree = transfo_trees[0]
+
+        name = "cluster_transfotree_{}".format(id)
+        url = url_for('transfotree', id=id, _external=True)
+        label = "TransfoTree: {name} ({id})".format_map(transfo_tree)
+
+        return Dot.transfo_trees(name, url, label, [id])

--- a/api_li3ds/dot.py
+++ b/api_li3ds/dot.py
@@ -1,103 +1,104 @@
+'''
+Graphviz wrapper to export li3ds database elements
+'''
 from flask import url_for
 from graphviz import Digraph
 
 from api_li3ds.database import Database
 
 
-class Dot():
-    '''
-    Graphviz wrapper to export li3ds database elements
-    '''
+def make_dot(name, url, label, nodes, edges):
+    dot = Digraph(name=name, comment=url)
+    dot.graph_attr.update({
+        'label': label,
+        'overlap': 'scalexy'
+    })
 
-    def dot(name, url, label, nodes, edges):
-        dot = Digraph(name=name, comment=url)
-        dot.graph_attr.update({
-            'label': label,
-            'overlap': 'scalexy'
-        })
+    subgraphs = {}
 
-        subgraphs = {}
+    for node in nodes:
+        if node.sensor not in subgraphs:
+            url = url_for('sensor', id=node.sensor, _external=True)
+            name = "cluster_sensor_{}".format(node.sensor)
+            label = "Sensor {type}: {sname} ({sensor})".format_map(node._asdict())
+            subgraphs[node.sensor] = Digraph(name=name, comment=url)
+            subgraphs[node.sensor].graph_attr.update({'label': label})
+        color = 'red' if node.root else 'black'
+        label = '{name}\\n({id})'.format_map(node._asdict())
+        subgraphs[node.sensor].node(str(node.id), label=label, color=color)
 
-        for node in nodes:
-            if node.sensor not in subgraphs:
-                url = url_for('sensor', id=node.sensor, _external=True)
-                name = "cluster_sensor_{}".format(node.sensor)
-                label = "Sensor {type}: {sname} ({sensor})".format_map(node._asdict())
-                subgraphs[node.sensor] = Digraph(name=name, comment=url)
-                subgraphs[node.sensor].graph_attr.update({'label': label})
-            color = 'red' if node.root else 'black'
-            label = '{name}\\n({id})'.format_map(node._asdict())
-            subgraphs[node.sensor].node(str(node.id), label=label, color=color)
+    for sensor in subgraphs:
+        dot.subgraph(subgraphs[sensor])
 
-        for sensor in subgraphs:
-            dot.subgraph(subgraphs[sensor])
+    for edge in edges:
+        # highlight sensor connections in blue
+        color = 'blue' if edge.sc else 'black'
+        label = '{tname}\\n({id})'.format_map(edge._asdict())
+        dot.edge(str(edge.source), str(edge.target), label=label, color=color)
 
-        for edge in edges:
-            # highlight sensor connections in blue
-            color = 'blue' if edge.sc else 'black'
-            label = '{tname}\\n({id})'.format_map(edge._asdict())
-            dot.edge(str(edge.source), str(edge.target), label=label, color=color)
+    dot.engine = 'dot'
+    return dot
 
-        dot.engine = 'dot'
-        return dot
 
-    def transfo_trees(name, url, label, ids):
+def transfo_trees(name, url, label, ids):
 
-        edges = Database.query(
-            """
-            select t.id, t.source, t.target, t.transfo_type, tf.sc, t.name, tft.name as tname
-            from (
-                select distinct
-                    unnest(tt.transfos) as tid, sensor_connections as sc
-                from li3ds.transfo_tree tt where tt.id = ANY(%s)
-            ) as tf
-            join li3ds.transfo t on t.id = tf.tid
-            join li3ds.transfo_type tft on tft.id = t.transfo_type
-            """, (list(ids), )
-        )
+    edges = Database.query(
+        """
+        select t.id, t.source, t.target, t.transfo_type, tf.sc, t.name, tft.name as tname
+        from (
+            select distinct
+                unnest(tt.transfos) as tid, sensor_connections as sc
+            from li3ds.transfo_tree tt where tt.id = ANY(%s)
+        ) as tf
+        join li3ds.transfo t on t.id = tf.tid
+        join li3ds.transfo_type tft on tft.id = t.transfo_type
+        """, (list(ids), )
+    )
 
-        urefs = set()
-        for edge in edges:
-            urefs.add(edge.source)
-            urefs.add(edge.target)
+    urefs = set()
+    for edge in edges:
+        urefs.add(edge.source)
+        urefs.add(edge.target)
 
-        nodes = Database.query("""
-            select distinct r.id, r.name, r.root, r.sensor, s.name as sname, s.type
-            from li3ds.referential r
-            join li3ds.sensor s on r.sensor = s.id
-            where ARRAY[r.id] <@ %s
-        """, (list(urefs), ))
+    nodes = Database.query("""
+        select distinct r.id, r.name, r.root, r.sensor, s.name as sname, s.type
+        from li3ds.referential r
+        join li3ds.sensor s on r.sensor = s.id
+        where ARRAY[r.id] <@ %s
+    """, (list(urefs), ))
 
-        return Dot.dot(name, url, label, nodes, edges)
+    return make_dot(name, url, label, nodes, edges)
 
-    def platform_config(id):
 
-        configs = Database.query_asdict("""
-            select p.name as pname, p.id as pid, c.transfo_trees, c.id, c.name
-            from li3ds.platform_config c
-            join li3ds.platform p on p.id = c.platform
-            where c.id = %s
-        """, (id, ))
+def platform_config(id):
 
-        if not configs:
-            return None
-        config = configs[0]
+    configs = Database.query_asdict("""
+        select p.name as pname, p.id as pid, c.transfo_trees, c.id, c.name
+        from li3ds.platform_config c
+        join li3ds.platform p on p.id = c.platform
+        where c.id = %s
+    """, (id, ))
 
-        name = "cluster_config_{}".format(id)
-        url = url_for('platform_config', id=id, _external=True)
-        label = "Platform: {pname} ({pid})\\nConfiguration: {name} ({id})".format_map(config)
-        return Dot.transfo_trees(name, url, label, config['transfo_trees'])
+    if not configs:
+        return None
+    config = configs[0]
 
-    def transfo_tree(id):
-        transfo_trees = Database.query_asdict(
-            "select * from li3ds.transfo_tree where id=%s", (id,)
-        )
-        if not transfo_trees:
-            return None
-        transfo_tree = transfo_trees[0]
+    name = "cluster_config_{}".format(id)
+    url = url_for('platform_config', id=id, _external=True)
+    label = "Platform: {pname} ({pid})\\nConfiguration: {name} ({id})".format_map(config)
+    return transfo_trees(name, url, label, config['transfo_trees'])
 
-        name = "cluster_transfotree_{}".format(id)
-        url = url_for('transfotree', id=id, _external=True)
-        label = "TransfoTree: {name} ({id})".format_map(transfo_tree)
 
-        return Dot.transfo_trees(name, url, label, [id])
+def transfo_tree(id):
+    tftrees = Database.query_asdict(
+        "select * from li3ds.transfo_tree where id=%s", (id,)
+    )
+    if not tftrees:
+        return None
+    transfo_tree = tftrees[0]
+
+    name = "cluster_transfotree_{}".format(id)
+    url = url_for('transfotree', id=id, _external=True)
+    label = "TransfoTree: {name} ({id})".format_map(transfo_tree)
+
+    return transfo_trees(name, url, label, [id])

--- a/api_li3ds/dot.py
+++ b/api_li3ds/dot.py
@@ -25,7 +25,7 @@ class Dot():
                 subgraphs[node.sensor] = Digraph(name=name, comment=url)
                 subgraphs[node.sensor].graph_attr.update({'label': label})
             color = 'red' if node.root else 'black'
-            label='{name}\\n({id})'.format_map(node._asdict())
+            label = '{name}\\n({id})'.format_map(node._asdict())
             subgraphs[node.sensor].node(str(node.id), label=label, color=color)
 
         for sensor in subgraphs:
@@ -34,8 +34,8 @@ class Dot():
         for edge in edges:
             # highlight sensor connections in blue
             color = 'blue' if edge.sc else 'black'
-            label='{tname}\\n({id})'.format_map(edge._asdict())
-            dot.edge(str(edge.source),str(edge.target),label=label,color=color)
+            label = '{tname}\\n({id})'.format_map(edge._asdict())
+            dot.edge(str(edge.source), str(edge.target), label=label, color=color)
 
         dot.engine = 'dot'
         return dot
@@ -82,7 +82,7 @@ class Dot():
             return None
         config = configs[0]
 
-        name="cluster_config_{}".format(id)
+        name = "cluster_config_{}".format(id)
         url = url_for('platform_config', id=id, _external=True)
         label = "Platform: {pname} ({pid})\\nConfiguration: {name} ({id})".format_map(config)
         print (config)


### PR DESCRIPTION
This PR is an attempt to address #8 :

- adds a `/platforms/configs/<config_id>/dot` to give access to the raw dot source in order to enable debuging, further manual tweaking or integration with other tools. This is done by factoring out a `platform_config_dot` function.
- the url of the config is added as a comment in the source
- referentials are grouped into sensor subgraphs, showing the sensor `name` and `id`
- transfos also show the `func_name` of their `transfo_type`
- the graph is labelled is with the configuration `name` and `id`, as well as the platform `id`

@ldgeo, I had to modify a bit the SQL queries. They appear to work on my simple tests but I am not sure they are optimal in general.

# Sample PNG output

![apili3ds-graph](https://cloud.githubusercontent.com/assets/7373521/23863881/3905a16e-0811-11e7-9e64-c3be0e363ab2.png)

# Sample DOT output
```
// http://localhost:5000/platforms/configs/5/dot/
digraph config_5 {
	graph [label="Platform 1 : config2_name (5)" overlap=scalexy]
		subgraph cluster_1 {
			graph [label="sensor1_name (1)"]
				1 [label="ref1_name
(1)" color=red]
				2 [label="ref2_name
(2)" color=red]
				3 [label="ref3_name
(3)" color=red]
		}
		subgraph cluster_2 {
			graph [label="sensor2_name (2)"]
				5 [label="ref4_name
(5)" color=red]
				6 [label="ref6_name
(6)" color=black]
		}
			1 -> 2 [label="transfotype1_name
(1)" color=black]
			2 -> 3 [label="transfotype1_name
(2)" color=black]
			5 -> 6 [label="transfotype3_name
(3)" color=black]
			3 -> 5 [label="transfotype3_name
(5)" color=blue]
}
```
