### PR TITLE
Update Docker image to use fdw-li3ds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,29 @@ RUN echo "host   all  all  0.0.0.0/0 md5" >> /etc/postgresql/9.5/main/pg_hba.con
 RUN echo "local  all  all            md5" >> /etc/postgresql/9.5/main/pg_hba.conf
 RUN echo "listen_addresses='*'"           >> /etc/postgresql/9.5/main/postgresql.conf
 
-# Install Python 3.5
-RUN apt-get update -y && \
-    apt-get install -y python3.5-dev python3-pip python3-setuptools python3-numpy postgresql-plpython3-9.5
-RUN pip3 install --upgrade pip
-
-# Install development packages
-RUN apt-get update -y && \
-    apt-get install -y git make autoconf libxml2-dev graphviz
+# Install Python 2.7 and Python 3.5
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        python2.7 \
+        python2.7-dev \
+        python-pip \
+        python-setuptools \
+        python-numpy \
+        python3.5 \
+        python3.5-dev \
+        python3-pip \
+        python3-setuptools \
+        python3-numpy \
+        postgresql-plpython3-9.5 \
+        git \
+        make \
+        build-essential \
+        autoconf \
+        automake \
+        libxml2-dev \
+        graphviz \
+    && pip install --upgrade pip \
+    && pip3 install --upgrade pip
 
 # Install pg_pointcloud
 RUN git clone https://github.com/pgpointcloud/pointcloud.git
@@ -25,19 +40,19 @@ RUN cd pointcloud && ./autogen.sh && ./configure && make -j3 && make install
 RUN git clone https://github.com/li3ds/pg_li3ds
 RUN cd pg_li3ds && make install
 
-# Install fdw-pointcloud
+# Install fdw-li3ds
 RUN git clone https://github.com/Kozea/Multicorn && \
     cd Multicorn && \
-    PYTHON_OVERRIDE=python3 make -j3 && \
-    PYTHON_OVERRIDE=python3 make install && \
+    PYTHON_OVERRIDE=python2 make -j3 && \
+    PYTHON_OVERRIDE=python2 make install && \
     cd .. && \
-    git clone https://github.com/LI3DS/fdw-pointcloud && \
-    cd fdw-pointcloud && \
-    pip3 install -e .
+    git clone https://github.com/LI3DS/fdw-li3ds && \
+    cd fdw-li3ds && \
+    pip2 install -e .
 
 # Install micmac_li3ds
 RUN git clone https://github.com/li3ds/micmac_li3ds.git
-RUN cd micmac_li3ds && pip install -e .
+RUN cd micmac_li3ds && pip3 install -e .
 
 # Create li3ds user and database
 USER postgres
@@ -50,8 +65,8 @@ RUN /etc/init.d/postgresql start && \
   psql -d li3ds --command "create extension pointcloud_postgis;" && \
   psql -d li3ds --command "create extension li3ds;" && \
   psql -d li3ds --command "create extension multicorn;" && \
-  psql -d li3ds --command "create server echopulse foreign data wrapper multicorn options ( wrapper 'fdwpointcloud.EchoPulse' );" && \
-  psql -d li3ds --command "create server sbet foreign data wrapper multicorn options ( wrapper 'fdwpointcloud.Sbet' );" && \
+  psql -d li3ds --command "create server echopulse foreign data wrapper multicorn options ( wrapper 'fdwli3ds.EchoPulse' );" && \
+  psql -d li3ds --command "create server sbet foreign data wrapper multicorn options ( wrapper 'fdwli3ds.Sbet' );" && \
   /etc/init.d/postgresql stop
 USER root
 


### PR DESCRIPTION
Update the Dockerfile to use fdw-li3ds rather than fdw-pointcloud. fdw-pointcloud was renamed to fdw-li3ds and Python 2.7 should now be used.