### PR TITLE
Return UTC date times

### DIFF
--- a/api_li3ds/apis/datasource.py
+++ b/api_li3ds/apis/datasource.py
@@ -3,6 +3,7 @@ from flask_restplus import fields
 
 from api_li3ds.app import api, Resource, defaultpayload
 from api_li3ds.database import Database
+from api_li3ds import fields as li3ds_fields
 
 
 nsds = api.namespace('datasources', description='datasources related operations')
@@ -12,8 +13,8 @@ datasource_model_post = nsds.model('Datasource Model Post', {
     'type': fields.String(required=True),
     'paramaters': fields.Raw,
     'bounds': fields.List(fields.Float),
-    'capture_start': fields.DateTime(dt_format='iso8601'),
-    'capture_end': fields.DateTime(dt_format='iso8601'),
+    'capture_start': li3ds_fields.DateTime(dt_format='iso8601'),
+    'capture_end': li3ds_fields.DateTime(dt_format='iso8601'),
     'referential': fields.Integer(required=True),
     'session': fields.Integer(required=True)
 })
@@ -24,7 +25,7 @@ datasource_model = nsds.inherit('Datasource Model', datasource_model_post, {
 })
 
 processing_model_post = nsds.model('Processing Model Post', {
-    'launched': fields.DateTime(dt_format='iso8601', default=None),
+    'launched': li3ds_fields.DateTime(dt_format='iso8601', default=None),
     'tool': fields.String(required=True),
     'description': fields.String,
     'source': fields.Integer(required=True),

--- a/api_li3ds/apis/platform.py
+++ b/api_li3ds/apis/platform.py
@@ -5,6 +5,8 @@ from flask_restplus import fields
 from api_li3ds.app import api, Resource, defaultpayload
 from api_li3ds.database import Database
 from api_li3ds import dot
+from api_li3ds import fields as li3ds_fields
+
 from .sensor import sensor_model
 
 nspfm = api.namespace('platforms', description='platforms related operations')
@@ -14,8 +16,8 @@ platform_model_post = nspfm.model(
     {
         'name': fields.String,
         'description': fields.String,
-        'start_time': fields.DateTime(dt_format='iso8601', default=None),
-        'end_time': fields.DateTime(dt_format='iso8601', default=None),
+        'start_time': li3ds_fields.DateTime(dt_format='iso8601', default=None),
+        'end_time': li3ds_fields.DateTime(dt_format='iso8601', default=None),
     })
 
 platform_model = nspfm.inherit(

--- a/api_li3ds/apis/referential.py
+++ b/api_li3ds/apis/referential.py
@@ -3,6 +3,7 @@ from flask_restplus import fields
 
 from api_li3ds.app import api, Resource, defaultpayload
 from api_li3ds.database import Database
+from api_li3ds import fields as li3ds_fields
 
 nsrf = api.namespace('referentials', description='referentials related operations')
 
@@ -32,9 +33,9 @@ transfo_model = nsrf.model(
         'transfo_type': fields.Integer,
         'description': fields.String,
         'parameters': fields.Raw,
-        'tdate': fields.DateTime(dt_format='iso8601'),
-        'validity_start': fields.DateTime(dt_format='iso8601', default=None),
-        'validity_end': fields.DateTime(dt_format='iso8601', default=None),
+        'tdate': li3ds_fields.DateTime(dt_format='iso8601'),
+        'validity_start': li3ds_fields.DateTime(dt_format='iso8601', default=None),
+        'validity_end': li3ds_fields.DateTime(dt_format='iso8601', default=None),
     })
 
 

--- a/api_li3ds/apis/session.py
+++ b/api_li3ds/apis/session.py
@@ -3,6 +3,7 @@ from flask_restplus import fields
 
 from api_li3ds.app import api, Resource, defaultpayload
 from api_li3ds.database import Database
+from api_li3ds import fields as li3ds_fields
 from .datasource import datasource_model
 
 nssession = api.namespace('sessions', description='sessions related operations')
@@ -10,8 +11,8 @@ nssession = api.namespace('sessions', description='sessions related operations')
 session_model_post = nssession.model('Session Model Post', {
     'name': fields.String,
     'platform': fields.Integer(required=True),
-    'start_time': fields.DateTime(dt_format='iso8601', default=None),
-    'end_time': fields.DateTime(dt_format='iso8601', default=None),
+    'start_time': li3ds_fields.DateTime(dt_format='iso8601', default=None),
+    'end_time': li3ds_fields.DateTime(dt_format='iso8601', default=None),
     'project': fields.Integer(required=True),
 })
 

--- a/api_li3ds/apis/transfo.py
+++ b/api_li3ds/apis/transfo.py
@@ -3,6 +3,7 @@ from flask_restplus import fields
 
 from api_li3ds.app import api, Resource, defaultpayload
 from api_li3ds.database import Database
+from api_li3ds import fields as li3ds_fields
 
 nstf = api.namespace('transfos', description='transformations related operations')
 
@@ -16,9 +17,9 @@ transfo_model_post = nstf.model(
         'transfo_type': fields.Integer,
         'description': fields.String,
         'parameters': fields.Raw,
-        'tdate': fields.DateTime(dt_format='iso8601'),
-        'validity_start': fields.DateTime(dt_format='iso8601'),
-        'validity_end': fields.DateTime(dt_format='iso8601'),
+        'tdate': li3ds_fields.DateTime(dt_format='iso8601'),
+        'validity_start': li3ds_fields.DateTime(dt_format='iso8601'),
+        'validity_end': li3ds_fields.DateTime(dt_format='iso8601'),
     })
 
 transfo_model = nstf.inherit(

--- a/api_li3ds/fields.py
+++ b/api_li3ds/fields.py
@@ -1,0 +1,9 @@
+import datetime
+from flask_restplus import fields
+
+
+class DateTime(fields.DateTime):
+
+    def format_iso8601(self, dt):
+        dt_utc = dt.replace(tzinfo=datetime.timezone.utc) - dt.utcoffset()
+        return dt_utc.isoformat()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,0 +1,14 @@
+import pytest
+
+from api_li3ds.fields import DateTime
+
+
+@pytest.fixture
+def datetime():
+    datetime = DateTime(dt_format='iso8601')
+    return datetime
+
+
+def test_DateTime(datetime):
+    assert datetime.format('2011-10-05T17:31:16.32+02') == \
+            '2011-10-05T15:31:16.320000+00:00'


### PR DESCRIPTION
Use our own DateTime field instead of flask_restplus'. This is so the API always returns UTC date times, using this format:

    011-10-05T15:31:16.320000+00:00