### PR TITLE
pcid space starts from 1

### DIFF
--- a/api_li3ds/apis/foreignpc.py
+++ b/api_li3ds/apis/foreignpc.py
@@ -158,7 +158,7 @@ class ForeignTable(Resource):
             server {server} options (metadata 'true');
 
             with tmp as (
-                select coalesce(max(pcid) + 1, 0) as newid from pointcloud_formats
+                select coalesce(max(pcid) + 1, 1) as newid from pointcloud_formats
             )
             insert into pointcloud_formats(pcid, srid, schema)
             select tmp.newid, %(srid)s, schema from {schema}.{tablename}_schema, tmp


### PR DESCRIPTION
We currently get a "constraint" error at foreign table creation time when the pointcloud_formats table is empty.