### PR TITLE
Make foreignpc endpoint consistent with the rest of the API

### DIFF
--- a/api_li3ds/apis/foreignpc.py
+++ b/api_li3ds/apis/foreignpc.py
@@ -3,6 +3,7 @@ from flask_restplus import fields
 
 from api_li3ds.app import api, Resource, defaultpayload
 from api_li3ds.database import Database
+from api_li3ds.exc import abort
 
 
 nsfpc = api.namespace(
@@ -110,7 +111,7 @@ class ForeignServers(Resource):
         drivers = drivers.strip('NOTICE: \n').split(',')
 
         if api.payload['driver'] not in drivers:
-            return api.abort(
+            return abort(
                 404,
                 '{} driver does not exist, available drivers are {}'
                 .format(api.payload['driver'], drivers))
@@ -153,7 +154,7 @@ class ForeignTable(Resource):
         payload = defaultpayload(api.payload)
 
         if len(payload['table'].split('.')) != 2:
-            api.abort(404, 'table should be in the form schema.table')
+            abort(404, 'table should be in the form schema.table ({table})'.format(**payload))
 
         schema, tablename = payload['table'].split('.')
 
@@ -161,11 +162,11 @@ class ForeignTable(Resource):
             if payload['server'] == server['name']:
                 break
         else:
-            api.abort(404, 'no server {}'.format(payload['server']))
+            abort(404, 'no server {}'.format(payload['server']))
 
         if server['driver'] == 'fdwli3ds.Rosbag':
             if 'topic' not in payload.get('options', {}):
-                api.abort(404, '"topic" option required for Rosbag')
+                abort(404, '"topic" option required for Rosbag')
             schema_options = ", topic '{}'".format(payload['options']['topic'])
         else:
             schema_options = ''

--- a/api_li3ds/apis/foreignpc.py
+++ b/api_li3ds/apis/foreignpc.py
@@ -118,7 +118,9 @@ class ForeignServers(Resource):
 
         Database.rowcount(req)
 
-        return "foreign server created", 201
+        req = servers_sql + ' where srvname = %(name)s'
+
+        return Database.query_asjson(req, defaultpayload(api.payload)), 201
 
 
 @nsfpc.route('/tables/', endpoint='foreigntable')

--- a/api_li3ds/apis/foreignpc.py
+++ b/api_li3ds/apis/foreignpc.py
@@ -65,10 +65,6 @@ servers_sql = """
              where option_name != 'wrapper'), '{}'::jsonb)
           as "options"
     from pg_catalog.pg_foreign_server s
-        join pg_catalog.pg_foreign_data_wrapper f on f.oid=s.srvfdw
-    left join pg_description d
-        on d.classoid = s.tableoid
-        and d.objoid = s.oid and d.objsubid = 0
 """
 
 

--- a/api_li3ds/apis/foreignpc.py
+++ b/api_li3ds/apis/foreignpc.py
@@ -112,7 +112,7 @@ class ForeignServers(Resource):
         if api.payload['driver'] not in drivers:
             return api.abort(
                 404,
-                '{} driver does not exists, available drivers are {}'
+                '{} driver does not exist, available drivers are {}'
                 .format(api.payload['driver'], drivers))
 
         api.payload.update(

--- a/api_li3ds/apis/foreignpc.py
+++ b/api_li3ds/apis/foreignpc.py
@@ -53,7 +53,8 @@ multicorn_drivers_sql = """
 
 servers_sql = """
     select
-        s.srvname as "name"
+        s.srvname as id
+        , s.srvname as "name"
         , coalesce(
             (select option_value
              from pg_options_to_table(srvoptions)

--- a/api_li3ds/apis/foreignpc.py
+++ b/api_li3ds/apis/foreignpc.py
@@ -215,7 +215,11 @@ class ForeignTable(Resource):
                 )
             """.format(**payload)
         )
-        return "foreign table created", 201
+
+        req = tables_sql + ' where c.relname = %(tablename)s and s.srvname = %(server)s' \
+                           ' and n.nspname = %(schema)s'
+
+        return Database.query_asjson(req, payload), 201
 
 
 @nsfpc.route('/schema', endpoint='foreignschema')

--- a/api_li3ds/apis/foreignpc.py
+++ b/api_li3ds/apis/foreignpc.py
@@ -72,7 +72,7 @@ servers_sql = """
 """
 
 
-@nsfpc.route('/drivers', endpoint='foreigndrivers')
+@nsfpc.route('/drivers/', endpoint='foreigndrivers')
 class ForeignDrivers(Resource):
 
     def get(self):
@@ -83,7 +83,7 @@ class ForeignDrivers(Resource):
         return drivers.strip('NOTICE: \n').split(',')
 
 
-@nsfpc.route('/servers', endpoint='foreignservers')
+@nsfpc.route('/servers/', endpoint='foreignservers')
 class ForeignServers(Resource):
 
     def get(self):
@@ -125,7 +125,7 @@ class ForeignServers(Resource):
         return "foreign server created", 201
 
 
-@nsfpc.route('/table', endpoint='foreigntable')
+@nsfpc.route('/tables/', endpoint='foreigntable')
 class ForeignTable(Resource):
 
     @api.secure

--- a/api_li3ds/apis/foreignpc.py
+++ b/api_li3ds/apis/foreignpc.py
@@ -68,6 +68,17 @@ servers_sql = """
 """
 
 
+tables_sql = """
+    select
+        n.nspname || '.' || c.relname as table
+        , s.srvname as server
+    from pg_catalog.pg_class c
+    join pg_catalog.pg_foreign_table t on t.ftrelid=c.oid
+    join pg_catalog.pg_foreign_server s on s.oid=t.ftserver
+    join pg_catalog.pg_namespace n on n.oid=c.relnamespace
+"""
+
+
 @nsfpc.route('/drivers/', endpoint='foreigndrivers')
 class ForeignDrivers(Resource):
 
@@ -125,6 +136,12 @@ class ForeignServers(Resource):
 
 @nsfpc.route('/tables/', endpoint='foreigntable')
 class ForeignTable(Resource):
+
+    def get(self):
+        '''
+        Retrieve foreign table list
+        '''
+        return Database.query_asjson(tables_sql)
 
     @api.secure
     @nsfpc.expect(foreignpc_table_model)

--- a/api_li3ds/app.py
+++ b/api_li3ds/app.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from flask import request, current_app
 from flask_restplus import Api, Resource as OrigResource
 
-from api_li3ds.database import pgexceptions
+from api_li3ds.exc import pgexceptions
 
 HEADER_API_KEY = 'X-API-KEY'
 

--- a/api_li3ds/database.py
+++ b/api_li3ds/database.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from itertools import chain
-from psycopg2 import connect
+from psycopg2 import connect, sql
 from psycopg2.extras import NamedTupleCursor, Json, register_default_jsonb
 from psycopg2.extensions import register_adapter
 
@@ -27,9 +27,12 @@ class Database():
         '''
         cur = cls.db.cursor()
         cur.execute(query, parameters)
+
+        query_str = query.as_string(cur) if isinstance(query, sql.Composable) else query
         current_app.logger.debug(
-            'query: {}, rowncount: {}'.format(query, cur.rowcount)
+            'query: {}, rowncount: {}'.format(query_str, cur.rowcount)
         )
+
         if rowcount:
             yield cur.rowcount
             return

--- a/api_li3ds/database.py
+++ b/api_li3ds/database.py
@@ -1,39 +1,17 @@
 # -*- coding: utf-8 -*-
 from itertools import chain
-from functools import wraps
-
 from psycopg2 import connect
 from psycopg2.extras import NamedTupleCursor, Json, register_default_jsonb
-from psycopg2 import Error as PsycoError, IntegrityError as PsycoIntegrityError
 from psycopg2.extensions import register_adapter
 
 from flask import current_app
-import flask_restplus
+
 
 # adapt python dict to postgresql json type
 register_adapter(dict, Json)
 
 # register the jsonb type
 register_default_jsonb()
-
-
-def abort(exc, status_code):
-    current_app.logger.error(exc.pgerror or exc.args)
-    msg = '{} - {}'.format(exc.diag.message_detail, exc.diag.message_primary) if \
-          current_app.debug else 'Database Error'
-    return flask_restplus.abort(status_code, msg)
-
-
-def pgexceptions(func):
-    @wraps(func)
-    def decorated(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except PsycoIntegrityError as exc:
-            return abort(exc, 404)
-        except PsycoError as exc:
-            return abort(exc, 400)
-    return decorated
 
 
 class Database():

--- a/api_li3ds/exc.py
+++ b/api_li3ds/exc.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+import psycopg2
+import flask_restplus
+import functools
+
+from flask import current_app
+
+
+def abort(status_code, http_msg, log_msg=None):
+    """abort the current request, loggin an error message
+    """
+    if not log_msg:
+        log_msg = http_msg
+    current_app.logger.error(log_msg)
+    return flask_restplus.abort(status_code, http_msg)
+
+
+def abort_pgexc(status_code, exc):
+    """abort on a postgres exception
+    """
+    http_msg = '{} - {}'.format(exc.diag.message_detail, exc.diag.message_primary) if \
+               current_app.debug else 'Database Error'
+    return abort(status_code, http_msg, exc.pgerror or exc.args)
+
+
+def pgexceptions(func):
+    @functools.wraps(func)
+    def decorated(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except psycopg2.IntegrityError as exc:
+            return abort_pgexc(404, exc)
+        except psycopg2.Error as exc:
+            return abort_pgexc(400, exc)
+    return decorated

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 requirements = (
     'flask==0.11.1',
     'flask-restplus==0.10.0',
-    'psycopg2==2.6.2',
+    'psycopg2==2.7.3',
     'pyyaml',
     'graphviz>=0.5.1'
 )


### PR DESCRIPTION
This PR aims to make the foreignpc endpoint more consistent with the rest of the API. This is required for cli-li3ds, which treats all the API objects in the same way.

WIP for the moment.